### PR TITLE
Fix `No knowns class method for selector 'initWithUUIDString:'`

### DIFF
--- a/RCTDeviceUUID.m
+++ b/RCTDeviceUUID.m
@@ -20,7 +20,7 @@ RCT_EXPORT_METHOD(getUUID:(RCTResponseSenderBlock)callback)
   NSUUID *deviceId;
 
 #if TARGET_IPHONE_SIMULATOR
-  deviceId = [NSUUID initWithUUIDString:@"UUID-STRING-VALUE"];
+  deviceId = [[NSUUID alloc]initWithUUIDString:@"UUID-STRING-VALUE"];
 #else
   deviceId = [UIDevice currentDevice].identifierForVendor;
 #endif


### PR DESCRIPTION
The error `No knowns class method for selector 'initWithUUIDString:'` occurred while building the app for simulator.
