### PR TITLE
fixed RCTBridgeModule error that occurs when RN already imports it ca…

### DIFF
--- a/RCTDeviceUUID.h
+++ b/RCTDeviceUUID.h
@@ -6,7 +6,13 @@
 //  Copyright (c) 2015 Johannes Lumpe. All rights reserved.
 //
 
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
 #import "RCTBridgeModule.h"
+#endif
+#import "RCTBridge.h"
+
 #import "RCTLog.h"
 
 @interface RCTDeviceUUID : NSObject <RCTBridgeModule>


### PR DESCRIPTION
fixing this error about duplicate definitions:


`In file included from /Users/xxxxxx/Documents/projects/xxxxxx/xxxxxx/node_modules/react-native-device-uuid/RCTDeviceUUID.m:9:
In file included from /Users/xxxxxx/Documents/projects/xxxxxx/xxxxxx/node_modules/react-native-device-uuid/RCTDeviceUUID.h:10:
../react-native/React/Base/RCTBridgeModule.h:63:11: note: previous definition is here
@protocol RCTBridgeModule <NSObject>
          ^
1 warning and 2 errors generated.`